### PR TITLE
Fix the error in the "verify-clean-git-stage" rule of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,5 +73,4 @@ run:
 .PHONY: verify-clean-git-stage
 verify-clean-git-stage:
 	@echo -e "***** verify cleaniness of git staging area"
-	@[ -n "$(git status --porcelain)" ] || \
-	{ echo -e "ERROR: uncommited changes in commit area, either commit or ignore"; git status --porcelain; exit 1; }
+	@if [ -n "$$(git status --porcelain)" ]; then git status --porcelain; exit 1; fi


### PR DESCRIPTION
The first mistake was that `make` ate the `$`, have to use `$$` to
escape.

The second mistake with the old version, which was in the form of:

```bash
[ -n "$(git status --porcelain)" ] || \
{ echo "ERROR"; git status --porcelain; exit 1; }
```

was that if `[ -n "$(git status --porcelain)" ]` is `false` (which
would mean the staging area is clean and everything is good to move
on), it behaves like a failed process and exits (that's what `false`
is and does for such statement in bash), hence failing the the whole
bash process running the current line, and consequently the make
process.

The current version lets the `if` catch the potential fail (i.e. the
state being `false`). Alternatively, instead of using `if` to catch
the `false`, I could let it lead to an idle process with an "or" by
the use of `||:` where `:` does nothing. Something like:

```bash
[ -n "$$(git status --porcelain)" ] && \
{ echo "ERROR"; git status --porcelain; exit 1; } \
|| :
```