### PR TITLE
Fix bug in test

### DIFF
--- a/tests/test_logisticmap.py
+++ b/tests/test_logisticmap.py
@@ -85,4 +85,4 @@ class TestLogisticMap:
         X = lm.X.copy()
         lm.scramble()
         assert X.shape == lm.X.shape == (6, 3)
-        assert (lm.X != X).all()
+        assert (lm.X != X).any()


### PR DESCRIPTION
After scramble, not necessary `all` the entries change, so use `any`
instead.